### PR TITLE
Do not use h5py in split data by default, pyfact is broken for lists

### DIFF
--- a/klaas/scripts/split_data.py
+++ b/klaas/scripts/split_data.py
@@ -35,8 +35,11 @@ import warnings
     '--fmt', type=click.Choice(['csv', 'hdf5']), default='hdf5',
     help='The output format',
 )
+@click.option(
+    '--use-h5py', is_flag=True, help='Write h5py output files',
+)
 @click.option('-v', '--verbose', help='Verbose log output', type=bool)
-def main(input_path, output_basename, fraction, name, inkey, key, fmt, verbose):
+def main(input_path, output_basename, fraction, name, inkey, key, fmt, use_h5py, verbose):
     '''
     Split dataset in INPUT_PATH into multiple parts for given fractions and names
     Outputs pandas hdf5 or csv files to OUTPUT_BASENAME_NAME.FORMAT
@@ -70,7 +73,7 @@ def main(input_path, output_basename, fraction, name, inkey, key, fmt, verbose):
 
         if fmt == 'hdf5':
             path = output_basename + '_' + part_name + '.hdf5'
-            write_data(data.iloc[selected], path, key=key, use_hp5y=True)
+            write_data(data.iloc[selected], path, key=key, use_hp5y=use_h5py)
 
         elif fmt == 'csv':
             data.iloc[selected].to_csv(output_basename + '_' + part_name + '.csv')


### PR DESCRIPTION
Add option to use h5py output in split_data, do not use it by default.

Reason is a bug in pyfact: https://github.com/fact-project/pyfact/issues/69
This will be fixed when https://github.com/fact-project/pyfact/pull/70 is merged.