### PR TITLE
Use SkyCoordinates to calculate source pos, do not calculate theta

### DIFF
--- a/examples/config_source.yaml
+++ b/examples/config_source.yaml
@@ -14,6 +14,10 @@ sign_classifier: |
       max_depth=20,
   )
 
+source_azimuth_column: az_source_calc
+source_zenith_column: zd_source_calc
+pointing_azimuth_column: az_tracking
+pointing_zenith_column: zd_tracking
 
 
 # randomly sample the data if you dont want to use the whole set

--- a/klaas/scripts/apply_disp_regressor.py
+++ b/klaas/scripts/apply_disp_regressor.py
@@ -7,7 +7,6 @@ import h5py
 from tqdm import tqdm
 
 from fact.io import read_h5py_chunked
-from fact.instrument import camera_distance_mm_to_deg
 from ..preprocessing import convert_to_float32, check_valid_rows
 from ..feature_generation import feature_generation
 from ..io import append_to_h5py
@@ -45,7 +44,8 @@ def main(configuration_path, data_path, disp_model_path, sign_model_path, key, c
     training_variables = config['training_variables']
 
     columns_to_delete = [
-        'reconstructed_source_position',
+        'source_x_prediction',
+        'source_y_prediction',
         'theta',
         'theta_deg',
         'theta_rec_pos',
@@ -118,7 +118,8 @@ def main(configuration_path, data_path, disp_model_path, sign_model_path, key, c
         rec_pos[valid, 1] = df_data.cog_y + disp * np.sin(df_data.delta) * sign
 
         with h5py.File(data_path, 'r+') as f:
-            append_to_h5py(f, rec_pos, key, 'source_position_prediction')
+            append_to_h5py(f, rec_pos[:, 0], key, 'source_x_prediction')
+            append_to_h5py(f, rec_pos[:, 1], key, 'source_y_prediction')
             append_to_h5py(f, disp_prediction, key, 'disp_prediction')
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='klaas',
-    version='0.4.0',
+    version='0.5.0',
     description='KLAssification And regression Scripts.  yay',
     url='https://github.com/fact-project/klaas',
     author='Kai Brügge, Maximilian Nöthe, Jens Buss',
@@ -22,11 +22,11 @@ setup(
         'numexpr',
         'numpy',            # in anaconda
         'pandas',           # in anaconda
-        'pyfact>=0.12.0',
+        'pyfact>=0.13.0',
         'python-dateutil',  # in anaconda
         'pytz',             # in anaconda
         'pyyaml',             # in anaconda
-        'scikit-learn==0.18.1',
+        'scikit-learn==0.19.0',
         'sklearn2pmml',
         'tables',           # needs to be installed by pip for some reason
         'tqdm',


### PR DESCRIPTION
This is better because:

* We do not depend on the source transformations in fact-tools, which are known to be imprecise compared to astropy
* The application of the model in `klaas_apply_disp_regressor` becomes independent of a known source position.

For the analysis of known source positions, theta can later be calculated. 
I will add a script to do that.