### PR TITLE
Multi tel support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
 before_install:
   - export DISPLAY=:99.0

--- a/examples/config_energy.yaml
+++ b/examples/config_energy.yaml
@@ -40,7 +40,7 @@ training_variables:
 
 # Generate some features using pd.DataFrame.eval
 # List all keys that have to be read from the input files
-# in needed keys. 
+# in needed keys.
 # features must be a mapping of feature name -> expression
 feature_generation:
   needed_keys:

--- a/klaas/configuration.py
+++ b/klaas/configuration.py
@@ -50,8 +50,11 @@ class KlaasConfig():
             self.telescope_events_key = config.get('telescope_events_key', 'events')
             self.events_key = config.get('array_events_key', 'array_events')
 
+            self.run_id_key = config.get('run_id_key', 'run_id')
+            columns_to_read.append(self.run_id_key)
             self.array_event_id_key = config.get('array_event_id_key', 'array_event_id')
             columns_to_read.append(self.array_event_id_key)
+
         else:
             self.telescope_events_key = config.get('telescope_events_key', 'events')
 

--- a/klaas/configuration.py
+++ b/klaas/configuration.py
@@ -1,0 +1,73 @@
+from collections import namedtuple
+import yaml
+from sklearn import ensemble
+
+TrainingConfig = namedtuple('training_config', [
+    'n_background',
+    'n_signal',
+    'n_cross_validations',
+    'model',
+    'seed',
+])
+
+FeatureConfig = namedtuple('feature_generation', ['needed_keys', 'features'])
+
+
+class KlaasConfig():
+    feature_generation_config = None
+    telescope_events_key = 'telescope_events'
+    array_events_key = 'array_events'
+
+    def __init__(self, configuration_path):
+        with open(configuration_path) as f:
+            config = yaml.load(f)
+
+        n_background = config.get('n_background', None)
+        n_signal = config.get('n_signal', None)
+
+        n_cross_validations = config.get('n_cross_validations', 10)
+
+        self.seed = config.get('seed', 0)
+
+        if config.get('classifier'):
+            self.model = eval(config['classifier'])
+        else:
+            self.model = eval(config['regressor'])
+
+        self.model.random_state = self.seed
+
+        self.training_config = TrainingConfig(
+            n_background,
+            n_signal,
+            n_cross_validations,
+            self.model,
+            self.seed,
+        )
+
+        training_variables = config['training_variables']
+        columns_to_read = [] + config['training_variables']
+
+        generation_config = config.get('feature_generation')
+        if generation_config:
+            self.feature_generation_config = FeatureConfig(
+                generation_config.get('needed_keys'),
+                generation_config.get('features'))
+            training_variables += generation_config.get('features')
+
+        self.has_multiple_telescopes = config.get('multiple_telescopes', False)
+        if self.has_multiple_telescopes:
+            self.telescope_events_key = config.get('telescope_events_key', 'telescope_events')
+            self.events_key = config.get('array_events_key', 'array_events')
+            self.array_event_id_key = config.get('array_event_id_key', 'array_event_id')
+        else:
+            self.telescope_events_key = config.get('telescope_events_key', 'events')
+
+
+        self.log_target = config.get('log_target', False)
+        if config.get('target_name', None):
+            self.target_name = config['target_name']
+            columns_to_read += [config['target_name']]
+
+
+        self.training_variables = training_variables
+        self.columns_to_read = columns_to_read

--- a/klaas/configuration.py
+++ b/klaas/configuration.py
@@ -8,6 +8,7 @@ TrainingConfig = namedtuple('training_config', [
     'n_cross_validations',
     'model',
     'seed',
+    'training_variables'
 ])
 
 FeatureConfig = namedtuple('feature_generation', ['needed_keys', 'features'])
@@ -15,34 +16,22 @@ FeatureConfig = namedtuple('feature_generation', ['needed_keys', 'features'])
 
 class KlaasConfig():
     feature_generation_config = None
-    telescope_events_key = 'telescope_events'
+    training_config = None
+
+    telescope_events_key = 'events'
     array_events_key = 'array_events'
+    runs_key = 'runs'
+
+    has_multiple_telescopes = False
+    class_name = 'gamma'
+    seed = 0
 
     def __init__(self, configuration_path):
         with open(configuration_path) as f:
             config = yaml.load(f)
 
-        n_background = config.get('n_background', None)
-        n_signal = config.get('n_signal', None)
-
-        n_cross_validations = config.get('n_cross_validations', 10)
-
         self.seed = config.get('seed', 0)
-
-        if config.get('classifier'):
-            self.model = eval(config['classifier'])
-        else:
-            self.model = eval(config['regressor'])
-
-        self.model.random_state = self.seed
-
-        self.training_config = TrainingConfig(
-            n_background,
-            n_signal,
-            n_cross_validations,
-            self.model,
-            self.seed,
-        )
+        self.class_name = config.get('class_name', 'gamma')
 
         training_variables = config['training_variables']
         columns_to_read = [] + config['training_variables']
@@ -55,19 +44,40 @@ class KlaasConfig():
             training_variables += generation_config.get('features')
 
         self.has_multiple_telescopes = config.get('multiple_telescopes', False)
+
         if self.has_multiple_telescopes:
-            self.telescope_events_key = config.get('telescope_events_key', 'telescope_events')
+            self.runs_key = config.get('runs_key', 'runs')
+            self.telescope_events_key = config.get('telescope_events_key', 'events')
             self.events_key = config.get('array_events_key', 'array_events')
+
             self.array_event_id_key = config.get('array_event_id_key', 'array_event_id')
+            columns_to_read.append(self.array_event_id_key)
         else:
             self.telescope_events_key = config.get('telescope_events_key', 'events')
-
 
         self.log_target = config.get('log_target', False)
         if config.get('target_name', None):
             self.target_name = config['target_name']
             columns_to_read += [config['target_name']]
 
-
-        self.training_variables = training_variables
         self.columns_to_read = columns_to_read
+
+        # trainign configuration
+        n_background = config.get('n_background', None)
+        n_signal = config.get('n_signal', None)
+        n_cross_validations = config.get('n_cross_validations', 10)
+
+        if config.get('classifier'):
+            model = eval(config['classifier'])
+        else:
+            model = eval(config['regressor'])
+        model.random_state = self.seed
+
+        self.training_config = TrainingConfig(
+            n_background,
+            n_signal,
+            n_cross_validations,
+            model,
+            self.seed,
+            training_variables,
+        )

--- a/klaas/configuration.py
+++ b/klaas/configuration.py
@@ -65,7 +65,7 @@ class KlaasConfig():
 
         self.columns_to_read = columns_to_read
 
-        # trainign configuration
+        # training configuration
         n_background = config.get('n_background', None)
         n_signal = config.get('n_signal', None)
         n_cross_validations = config.get('n_cross_validations', 10)
@@ -84,3 +84,5 @@ class KlaasConfig():
             self.seed,
             training_variables,
         )
+
+        self.calibrate_classifier = config.get('calibrate_classifier', False)

--- a/klaas/feature_generation.py
+++ b/klaas/feature_generation.py
@@ -6,8 +6,8 @@ def feature_generation(df, config, inplace=False):
     if not inplace:
         df = df.copy()
 
-    for feature_name, expression in config['features'].items():
-        df[feature_name] = df.loc[:, config['needed_keys']].eval(expression)
+    for feature_name, expression in config.features.items():
+        df[feature_name] = df.loc[:, config.needed_keys].eval(expression)
 
     if not inplace:
         return df

--- a/klaas/features.py
+++ b/klaas/features.py
@@ -7,11 +7,17 @@ source_dependent_features = {
 }
 
 
-def find_used_source_features(used_features, generation_config=None):
-    used_source_feautures = set(filter(
+def has_source_dependent_columns(used_columns):
+    used_source_features = set(filter(
         lambda v: v in source_dependent_features,
-        used_features
+        used_columns
     ))
+
+    return len(used_source_features) > 0
+
+
+def find_used_source_features(used_features, generation_config=None):
+    used_source_feautures = set(filter(lambda v: v in source_dependent_features, used_features))
 
     if generation_config:
         used_source_feautures = used_source_feautures.union(set(filter(

--- a/klaas/io.py
+++ b/klaas/io.py
@@ -7,7 +7,7 @@ from .feature_generation import feature_generation
 from fact.io import read_data, h5py_get_n_rows
 import pandas as pd
 import h5py
-
+import click
 __all__ = ['pickle_model']
 
 
@@ -17,13 +17,20 @@ log = logging.getLogger(__name__)
 def check_existing_column(data_path, config, yes):
     prediction_column_name = config.class_name + '_prediction'
     with h5py.File(data_path, 'r+') as f:
-        if prediction_column_name in f[config.telescope_events_key].keys():
+        columns = f[config.telescope_events_key].keys()
+        if prediction_column_name in columns:
             if not yes:
                 click.confirm(
-                    f'Column \"{prediction_column_name}\" exists in file, overwrite?',
-                    abort=True,
+                    f'Column \"{prediction_column_name}\" exists in file, overwrite?', abort=True,
                 )
+
             del f[config.telescope_events_key][prediction_column_name]
+            if prediction_column_name + '_std' in columns:
+                del f[config.telescope_events_key][prediction_column_name + '_std']
+            if prediction_column_name + '_mean' in columns:
+                del f[config.telescope_events_key][prediction_column_name + '_mean']
+            if prediction_column_name + '_avg' in columns:
+                del f[config.telescope_events_key][prediction_column_name + '_avg']
 
 
 def read_telescope_data_chunked(path, klaas_config, chunksize, columns):

--- a/klaas/io.py
+++ b/klaas/io.py
@@ -14,23 +14,29 @@ __all__ = ['pickle_model']
 log = logging.getLogger(__name__)
 
 
-def check_existing_column(data_path, config, yes):
-    prediction_column_name = config.class_name + '_prediction'
+def drop_prediction_column(data_path, group_name, column_name, yes=True):
+    '''
+    Deletes prediction columns in a h5py file if the columns exist.
+    Including 'mean' and 'std' columns.
+    '''
     with h5py.File(data_path, 'r+') as f:
-        columns = f[config.telescope_events_key].keys()
-        if prediction_column_name in columns:
+
+        if group_name not in f.keys():
+            return
+
+        columns = f[group_name].keys()
+        if column_name in columns:
             if not yes:
                 click.confirm(
-                    f'Column \"{prediction_column_name}\" exists in file, overwrite?', abort=True,
+                    f'Column \"{column_name}\" exists in file, overwrite?', abort=True,
                 )
 
-            del f[config.telescope_events_key][prediction_column_name]
-            if prediction_column_name + '_std' in columns:
-                del f[config.telescope_events_key][prediction_column_name + '_std']
-            if prediction_column_name + '_mean' in columns:
-                del f[config.telescope_events_key][prediction_column_name + '_mean']
-            if prediction_column_name + '_avg' in columns:
-                del f[config.telescope_events_key][prediction_column_name + '_avg']
+            del f[group_name][column_name]
+
+        if column_name + '_std' in columns:
+            del f[group_name][column_name + '_std']
+        if column_name + '_mean' in columns:
+            del f[group_name][column_name + '_mean']
 
 
 def read_telescope_data_chunked(path, klaas_config, chunksize, columns):

--- a/klaas/io.py
+++ b/klaas/io.py
@@ -72,19 +72,22 @@ def read_telescope_data(path, klaas_config, n_sample=None, columns=None, first=N
                 array_event_columns = set(f[klaas_config.array_events_key].keys()) & set(columns)
                 telescope_event_columns = set(f[klaas_config.telescope_events_key].keys()) & set(columns)
 
-        df_features = read_data(
+        telescope_events = read_data(
             file_path=path,
             key=klaas_config.telescope_events_key,
             columns=telescope_event_columns,
             first=first,
             last=last,
         )
-        df_array_events = read_data(
+        array_events = read_data(
             file_path=path,
             key=klaas_config.array_events_key,
             columns=array_event_columns,
         )
-        df = pd.merge(left=df_array_events, right=df_features, on=klaas_config.array_event_id_key)
+
+        keys = [klaas_config.run_id_key, klaas_config.array_event_id_key]
+        df = pd.merge(left=array_events, right=telescope_events, left_on=keys, right_on=keys)
+
     else:
         df = read_data(
             file_path=path,

--- a/klaas/plotting.py
+++ b/klaas/plotting.py
@@ -48,7 +48,7 @@ def plot_bias_resolution(performace_df, bins=10, ax=None):
 
     if np.isscalar(bins):
         bins = np.logspace(
-            np.log10(df.label.min()),
+            np.log10(df.label.min()), d
             np.log10(df.label.max()),
             bins + 1
         )

--- a/klaas/plotting.py
+++ b/klaas/plotting.py
@@ -48,7 +48,7 @@ def plot_bias_resolution(performace_df, bins=10, ax=None):
 
     if np.isscalar(bins):
         bins = np.logspace(
-            np.log10(df.label.min()), d
+            np.log10(df.label.min()),
             np.log10(df.label.max()),
             bins + 1
         )

--- a/klaas/scripts/apply_regression_model.py
+++ b/klaas/scripts/apply_regression_model.py
@@ -89,7 +89,7 @@ def main(configuration_path, data_path, model_path, chunksize, n_jobs, yes, verb
             append_to_h5py(f, energy_prediction_std, config.telescope_events_key, prediction_column_name + '_std')
 
     if config.has_multiple_telescopes:
-        d = pd.concat(chunked_frames).groupby(['run_id', 'array_event_id']).agg(['mean', 'std'])
+        d = pd.concat(chunked_frames).groupby(['run_id', 'array_event_id'], sort=False).agg(['mean', 'std'])
         mean = d[prediction_column_name]['mean'].values
         std = d[prediction_column_name]['std'].values
         with h5py.File(data_path, 'r+') as f:

--- a/klaas/scripts/apply_separation_model.py
+++ b/klaas/scripts/apply_separation_model.py
@@ -76,7 +76,7 @@ def main(configuration_path, data_path, model_path, chunksize, yes, verbose):
 
     # combine predictions
     if config.has_multiple_telescopes:
-        d = pd.concat(chunked_frames).groupby(['run_id', 'array_event_id']).agg(['mean', 'std'])
+        d = pd.concat(chunked_frames).groupby(['run_id', 'array_event_id'], sort=False).agg(['mean', 'std'])
         mean = d[prediction_column_name]['mean'].values
         std = d[prediction_column_name]['std'].values
         with h5py.File(data_path, 'r+') as f:

--- a/klaas/scripts/apply_separation_model.py
+++ b/klaas/scripts/apply_separation_model.py
@@ -1,30 +1,27 @@
 import click
 from sklearn.externals import joblib
-import yaml
 import logging
 import h5py
 from tqdm import tqdm
 
-from fact.io import read_h5py_chunked
-
-from ..features import find_used_source_features
 from ..apply import predict
 from ..feature_generation import feature_generation
-from ..io import append_to_h5py
+from ..features import has_source_dependent_columns
+from ..io import append_to_h5py, read_telescope_data_chunked, check_existing_column
+from ..configuration import KlaasConfig
 
 
 @click.command()
 @click.argument('configuration_path', type=click.Path(exists=True, dir_okay=False))
 @click.argument('data_path', type=click.Path(exists=True, dir_okay=False))
 @click.argument('model_path', type=click.Path(exists=True, dir_okay=False))
-@click.option('-k', '--key', help='HDF5 key for h5py hdf5', default='events')
 @click.option('-v', '--verbose', help='Verbose log output', is_flag=True)
 @click.option(
     '-N', '--chunksize', type=int,
     help='If given, only process the given number of events at once'
 )
 @click.option('-y', '--yes', help='Do not prompt for overwrites', is_flag=True)
-def main(configuration_path, data_path, model_path, key, chunksize, yes, verbose):
+def main(configuration_path, data_path, model_path, chunksize, yes, verbose):
     '''
     Apply loaded model to data.
 
@@ -42,62 +39,34 @@ def main(configuration_path, data_path, model_path, key, chunksize, yes, verbose
     logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
     log = logging.getLogger()
 
-    with open(configuration_path) as f:
-        config = yaml.load(f)
+    config = KlaasConfig(configuration_path)
 
-    training_variables = config['training_variables']
-
-    prediction_column_name = config.get('class_name', 'gamma') + '_prediction'
-
-    with h5py.File(data_path, 'r+') as f:
-        if prediction_column_name in f[key].keys():
-            if not yes:
-                click.confirm(
-                    'Column "{}" exists in file, overwrite?'.format(prediction_column_name),
-                    abort=True,
-                )
-            del f[key][prediction_column_name]
-
-
-    log.info('Loading model')
-    model = joblib.load(model_path)
-    log.info('Done')
-
-    generation_config = config.get('feature_generation')
-    if len(find_used_source_features(training_variables, generation_config)) > 0:
+    if has_source_dependent_columns(config.columns_to_read):
         raise click.ClickException(
             'Using source dependent features in the model is not supported'
         )
 
-    needed_features = training_variables.copy()
-    if generation_config:
-        needed_features.extend(generation_config['needed_keys'])
+    check_existing_column(data_path, config, yes)
 
-    df_generator = read_h5py_chunked(
-        data_path,
-        key=key,
-        columns=needed_features,
-        chunksize=chunksize,
-        mode='r+'
-    )
+    log.debug('Loading model')
+    model = joblib.load(model_path)
+    log.debug('Loaded model')
 
-    if generation_config:
-        training_variables.extend(sorted(generation_config['features']))
+    df_generator = read_telescope_data_chunked(data_path, config, chunksize, config.columns_to_read)
 
     log.info('Predicting on data...')
+    prediction_column_name = config.class_name + '_prediction'
     for df_data, start, end in tqdm(df_generator):
 
-        if generation_config:
-            feature_generation(
-                df_data,
-                generation_config,
-                inplace=True,
-            )
+        if config.feature_generation_config:
+            feature_generation(df_data, config.feature_generation_config, inplace=True)
 
-        signal_prediction = predict(df_data, model, training_variables)
+        signal_prediction = predict(df_data, model, config.training_config.training_variables)
 
         with h5py.File(data_path, 'r+') as f:
-            append_to_h5py(f, signal_prediction, key, prediction_column_name)
+            append_to_h5py(f, signal_prediction, config.telescope_events_key, prediction_column_name)
+
+
 
 
 if __name__ == '__main__':

--- a/klaas/scripts/split_data.py
+++ b/klaas/scripts/split_data.py
@@ -6,6 +6,8 @@ from fact.io import read_data, write_data
 import warnings
 from math import ceil
 
+log = logging.getLogger()
+
 
 def split_indices(idx, n_total, fractions):
     '''
@@ -45,31 +47,67 @@ def split_indices(idx, n_total, fractions):
     show_default=True,
 )
 @click.option(
-    '--event_id_key',
-    '-d',
-    help='Name of the colum containing a unique id for each array-wide event.'
-         'If provided it will not split up rows that belong to the same event but to '
-         'different telescopes',
-    default=None
+    '--telescope', '-t', type=click.Choice(['fact', 'cta']), default='fact',
+    show_default=True, help='Which telescope created the data',
 )
 @click.option(
     '--fmt', type=click.Choice(['csv', 'hdf5', 'hdf', 'h5']), default='hdf5',
     show_default=True, help='The output format',
 )
 @click.option('-s', '--seed', help='Random Seed', type=int, default=0, show_default=True)
-@click.option('-v', '--verbose', help='Verbose log output', type=bool)
-def main(input_path, output_basename, fraction, name, inkey, key, event_id_key, fmt, seed, verbose):
+@click.option('-v', '--verbose', is_flag=True, help='Verbose log output',)
+def main(input_path, output_basename, fraction, name, inkey, key, telescope, fmt, seed, verbose):
     '''
     Split dataset in INPUT_PATH into multiple parts for given fractions and names
     Outputs hdf5 or csv files to OUTPUT_BASENAME_NAME.FORMAT
 
     Example call: klaas_split_data input.hdf5 output_base -n test -f 0.5 -n train -f 0.5
     '''
+
     logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
-    log = logging.getLogger()
+
     log.debug("input_path: {}".format(input_path))
 
     np.random.seed(seed)
+
+    if telescope == 'fact':
+        split_single_telescope_data(input_path, output_basename, fmt, inkey, key, fraction, name)
+    else:
+        split_multi_telescope_data(input_path, output_basename, fraction, name)
+
+
+def split_multi_telescope_data(input_path, output_basename, fraction, name):
+
+    array_events = read_data(input_path, key='array_events')
+    telescope_events = read_data(input_path, key='telescope_events')
+    runs = read_data(input_path, key='runs')
+
+    # split by runs
+
+    ids = set(runs.run_id)
+    log.debug(f'All runs:{ids}')
+    n_total = len(runs)
+
+    log.info(f'Found a total of {n_total} runs in the file')
+    num_runs = split_indices(ids, n_total, fractions=fraction)
+
+    for n, part_name in zip(num_runs, name):
+        selected_run_ids = np.random.choice(list(ids), size=n, replace=False)
+        selected_runs = runs[runs.run_id.isin(selected_run_ids)]
+        selected_array_events = array_events[array_events.run_id.isin(selected_run_ids)]
+        selected_telescope_events = telescope_events[telescope_events.run_id.isin(selected_run_ids)]
+
+        path = output_basename + '_' + part_name + '.hdf5'
+        log.info('Writing {} runs events to: {}'.format(n, path))
+        write_data(selected_runs, path, key='runs', use_h5py=True, mode='w')
+        write_data(selected_array_events, path, key='array_events', use_h5py=True, mode='a')
+        write_data(selected_telescope_events, path, key='telescope_events', use_h5py=True, mode='a')
+        log.debug(f'selected runs {set(selected_run_ids)}')
+        log.debug(f'Runs minus selected runs {ids - set(selected_run_ids)}')
+        ids = ids - set(selected_run_ids)
+
+
+def split_single_telescope_data(input_path, output_basename, fmt, inkey, key, fraction, name):
 
     if fmt in ['hdf5', 'hdf', 'h5']:
         data = read_data(input_path, key=inkey)
@@ -81,14 +119,8 @@ def main(input_path, output_basename, fraction, name, inkey, key, event_id_key, 
     if sum(fraction) != 1:
         warnings.warn('Fractions do not sum up to 1')
 
-    # set the ids we can split by to be either telescope events or array-wide events
     ids = data.index.values
     n_total = len(data)
-
-    if event_id_key:
-        ids = data[event_id_key].unique()
-        n_total = len(ids)
-        log.info('Found {} telescope-array events'.format(n_total))
 
     log.info('Found a total of {} single-telescope events in the file'.format(len(data)))
 
@@ -96,10 +128,7 @@ def main(input_path, output_basename, fraction, name, inkey, key, event_id_key, 
 
     for n, part_name in zip(num_ids, name):
         selected_ids = np.random.choice(ids, size=n, replace=False)
-        if event_id_key:
-            selected_data = data.loc[data[event_id_key].isin(selected_ids)]
-        else:
-            selected_data = data.loc[selected_ids]
+        selected_data = data.loc[selected_ids]
 
         if fmt in ['hdf5', 'hdf', 'h5']:
             path = output_basename + '_' + part_name + '.hdf5'
@@ -112,8 +141,4 @@ def main(input_path, output_basename, fraction, name, inkey, key, event_id_key, 
             selected_data.to_csv(filename, index=False)
 
         data = data.loc[list(set(data.index.values) - set(selected_data.index.values))]
-
-        if event_id_key:
-            ids = data[event_id_key].unique()
-        else:
-            ids = data.index.values
+        ids = data.index.values

--- a/klaas/scripts/train_energy_regressor.py
+++ b/klaas/scripts/train_energy_regressor.py
@@ -4,16 +4,17 @@ from sklearn import model_selection
 from sklearn import metrics
 from tqdm import tqdm
 import numpy as np
-import yaml
-from sklearn import ensemble
 
-from fact.io import write_data, read_data
-from ..io import pickle_model
+from fact.io import write_data
+from ..io import pickle_model, read_and_sample_data
 from ..preprocessing import convert_to_float32
 from ..feature_generation import feature_generation
-from ..features import find_used_source_features
-
+from ..features import has_source_dependent_columns
+from ..configuration import KlaasConfig
 import logging
+
+logging.basicConfig()
+log = logging.getLogger()
 
 
 @click.command()
@@ -38,74 +39,41 @@ def main(configuration_path, signal_path, predictions_path, model_path, key, ver
         Allowed extensions are .pkl and .pmml.
         If extension is .pmml, then both pmml and pkl file will be saved
     '''
+    logging.getLogger().setLevel(logging.DEBUG if verbose else logging.INFO)
 
-    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
-    log = logging.getLogger()
+    config = KlaasConfig(configuration_path)
 
-    with open(configuration_path) as f:
-        config = yaml.load(f)
-
-    seed = config.get('seed', 0)
-    np.random.seed(seed)
-
-    n_signal = config.get('n_signal')
-
-    n_cross_validations = config['n_cross_validations']
-    training_variables = config['training_variables']
-    target_name = config.get('target_name', 'corsika_event_header_total_energy')
-
-    log_target = config.get('log_target', False)
-
-    regressor = eval(config['regressor'])
-    regressor.random_state = seed
-
-    columns_to_read = training_variables + [target_name]
-
-    # Also read columns needed for feature generation
-    generation_config = config.get('feature_generation')
-    if generation_config:
-        columns_to_read.extend(generation_config.get('needed_keys', []))
-
-    if len(find_used_source_features(training_variables, generation_config)) > 0:
+    if has_source_dependent_columns(config.columns_to_read):
         raise click.ClickException(
             'Using source dependent features in the model is not supported'
         )
 
-    log.info('Loading data')
-    df = read_data(
-        file_path=signal_path,
-        key=key,
-        columns=columns_to_read,
-    )
+    df = read_and_sample_data(signal_path, config, n_sample=config.training_config.n_signal)
 
     log.info('Total number of events: {}'.format(len(df)))
 
     # generate features if given in config
-    if generation_config:
-        gen_config = config['feature_generation']
-        training_variables.extend(sorted(gen_config['features']))
-        feature_generation(df, gen_config, inplace=True)
+    if config.feature_generation_config:
+        feature_generation(df, config.feature_generation_config, inplace=True)
 
-    df_train = convert_to_float32(df[training_variables])
+    df_train = convert_to_float32(df[config.training_variables])
     df_train.dropna(how='any', inplace=True)
-
-    if n_signal:
-        log.info('Sampling {} random events'.format(n_signal))
-        df_train = df_train.sample(n_signal, random_state=seed)
 
     log.info('Events after nan-dropping: {} '.format(len(df_train)))
 
-    target = df[target_name].loc[df_train.index]
+    target = df[config.target_name].loc[df_train.index]
     target.name = 'true_energy'
 
-    if log_target is True:
+    if config.log_target is True:
         target = np.log(target)
 
+    n_cross_validations = config.training_config.n_cross_validations
+    regressor = config.training_config.model
     log.info('Starting {} fold cross validation... '.format(n_cross_validations))
     scores = []
     cv_predictions = []
 
-    kfold = model_selection.KFold(n_splits=n_cross_validations, shuffle=True, random_state=seed)
+    kfold = model_selection.KFold(n_splits=n_cross_validations, shuffle=True, random_state=config.seed)
 
     for fold, (train, test) in tqdm(enumerate(kfold.split(df_train.values))):
 
@@ -115,7 +83,7 @@ def main(configuration_path, signal_path, predictions_path, model_path, key, ver
         regressor.fit(cv_x_train, cv_y_train)
         cv_y_prediction = regressor.predict(cv_x_test)
 
-        if log_target is True:
+        if config.log_target is True:
             cv_y_test = np.exp(cv_y_test)
             cv_y_prediction = np.exp(cv_y_prediction)
 

--- a/klaas/scripts/train_separation_model.py
+++ b/klaas/scripts/train_separation_model.py
@@ -4,70 +4,18 @@ from sklearn import model_selection
 from tqdm import tqdm
 import numpy as np
 from sklearn import metrics
-import yaml
 import logging
-from sklearn import ensemble
-from fact.io import read_data, write_data, check_extension
+from fact.io import check_extension, write_data
 
-from ..io import pickle_model
+from ..configuration import KlaasConfig
+from ..io import pickle_model, read_and_sample_data
 from ..preprocessing import convert_to_float32
-from ..feature_generation import feature_generation
-from ..features import find_used_source_features
+
+from ..features import has_source_dependent_columns
 
 
 logging.basicConfig()
 log = logging.getLogger()
-
-
-def read_and_sample_data(path, key, columns_to_read, n_sample=None):
-    '''
-    Read given columns from data and perform a random sample if n_sample is supplied.
-    Returns a single pandas data frame
-    '''
-    df = read_data(
-        file_path=path,
-        key=key,
-        columns=columns_to_read,
-    )
-
-    if n_sample is not None:
-        if n_sample > len(df):
-            log.error(
-                'number of sampled events {} must be smaller than number events in file {} ({})'
-                .format(n_sample, path, len(df))
-            )
-            raise ValueError
-        log.info('Randomly sample {} events'.format(n_sample))
-        df = df.sample(n_sample)
-    return df
-
-
-def read_config(configuration_path):
-    '''
-    Read and return the values from the configuration file as a tuple
-    '''
-    with open(configuration_path) as f:
-        config = yaml.load(f)
-
-    n_background = config.get('n_background')
-    n_signal = config.get('n_signal')
-
-    n_cross_validations = config.get('n_cross_validations', 10)
-    training_variables = config['training_variables']
-
-    classifier = eval(config['classifier'])
-
-    generation_config = config.get('feature_generation')
-
-    telescope_type_column = config.get('telescope_type_key', None)
-
-    seed = config.get('seed', 0)
-
-    np.random.seed(seed)
-    classifier.random_state = seed
-
-    return (n_background, n_signal, n_cross_validations, training_variables, classifier,
-            generation_config, telescope_type_column, seed)
 
 
 @click.command()
@@ -100,42 +48,29 @@ def main(configuration_path, signal_path, background_path, predictions_path, mod
     check_extension(predictions_path)
     check_extension(model_path, allowed_extensions=['.pmml', '.pkl'])
 
-    (n_background, n_signal, n_cross_validations, training_variables, classifier,
-        generation_config, telescope_type_column, seed) = read_config(configuration_path)
 
-    columns_to_read = [] + training_variables
+    klaas_config = KlaasConfig(configuration_path)
+    tc = klaas_config.training_config
 
-    if len(find_used_source_features(training_variables, generation_config)) > 0:
+    if has_source_dependent_columns(klaas_config.columns_to_read):
         raise click.ClickException(
             'Using source dependent features in the model is not supported'
         )
 
-    # Also read columns needed for feature generation
-    if generation_config:
-        columns_to_read.extend(generation_config.get('needed_keys', []))
-
-    if telescope_type_column:
-        if telescope_type_column not in columns_to_read:
-            columns_to_read.append(telescope_type_column)
-
     log.info('Loading signal data')
-    df_signal = read_and_sample_data(signal_path, key, columns_to_read, n_signal)
+    df_signal = read_and_sample_data(signal_path, klaas_config, tc.n_signal)
     df_signal['label_text'] = 'signal'
     df_signal['label'] = 1
 
     log.info('Loading background data')
-    df_background = read_and_sample_data(background_path, key, columns_to_read, n_background)
+    df_background = read_and_sample_data(background_path, klaas_config, tc.n_background)
     df_background['label_text'] = 'background'
     df_background['label'] = 0
 
     df_full = pd.concat([df_background, df_signal], ignore_index=True)
 
-    # generate features if given in config
-    if generation_config:
-        training_variables.extend(sorted(generation_config['features']))
-        feature_generation(df_full, generation_config, inplace=True)
 
-    df_training = convert_to_float32(df_full[training_variables])
+    df_training = convert_to_float32(df_full[klaas_config.training_variables])
     log.info('Total training events: {}'.format(len(df_training)))
 
     df_training.dropna(how='any', inplace=True)
@@ -148,17 +83,21 @@ def main(configuration_path, signal_path, background_path, predictions_path, mod
     log.info('Training classifier with {} background and {} signal events'.format(
         n_protons, n_gammas
     ))
-    log.info(training_variables)
+    log.info(klaas_config.training_variables)
 
     # save prediction_path for each cv iteration
     cv_predictions = []
+
     # iterate over test and training sets
     X = df_training.values
     y = label.values
+    n_cross_validations = tc.n_cross_validations
+    classifier = tc.model
+
     log.info('Starting {} fold cross validation... '.format(n_cross_validations))
 
     stratified_kfold = model_selection.StratifiedKFold(
-        n_splits=n_cross_validations, shuffle=True, random_state=seed
+        n_splits=n_cross_validations, shuffle=True, random_state=tc.seed
     )
 
     aucs = []
@@ -173,20 +112,18 @@ def main(configuration_path, signal_path, background_path, predictions_path, mod
         y_probas = classifier.predict_proba(xtest)[:, 1]
         y_prediction = classifier.predict(xtest)
 
-        telescope_types = df_full.iloc[test][telescope_type_column] if telescope_type_column else 0
         cv_predictions.append(pd.DataFrame({
             'label': ytest,
             'label_prediction': y_prediction,
             'probabilities': y_probas,
             'cv_fold': fold,
-            'telescope_type': telescope_types
         }))
         aucs.append(metrics.roc_auc_score(ytest, y_probas))
 
     log.info('Mean AUC ROC : {}'.format(np.array(aucs).mean()))
 
     predictions_df = pd.concat(cv_predictions, ignore_index=True)
-    log.info('writing predictions from cross validation')
+    log.info('Writing predictions from cross validation')
     write_data(predictions_df, predictions_path, mode='w')
 
     log.info('Training model on complete dataset')


### PR DESCRIPTION

Read/Apply/Split on hdf5 data that contains these three groups:
1. `runs` all run related info
2. `array_events` all event-wide information which is the same for all telescopes in the array
3. `telescope_events` image parameters and pointing and such

Allow training of a http://scikit-learn.org/stable/modules/generated/sklearn.calibration.CalibratedClassifierCV.html which is usefull when there are mutliple telescope predictions to be merged together.

Add Configuration object. There was a lot of duplication going while reading configuration data. 
Not too happy with this part.

Whats missing:

refactor disp training and apppliying for cta/multiple-telescopes.